### PR TITLE
✨ chore: specify GoReleaser command in workflow file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,5 +76,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
+          args: release # Specify the GoReleaser command
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add the 'args: release' parameter to the GoReleaser action in the  GitHub Actions workflow. This change ensures that the correct  GoReleaser command is executed during the release process,  improving the automation of the release pipeline.