### PR TITLE
✨ feat: enable manual triggering for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
       - '**/*.go'
       - 'go.mod'
       - 'go.sum'
+  workflow_dispatch: # Allow manual triggering of the workflow
 
 jobs:
   build-test:


### PR DESCRIPTION
Adds `workflow_dispatch` to the release workflow configuration,  allowing users to manually trigger the workflow as needed. This  enhancement improves flexibility in managing releases.